### PR TITLE
<feat>: add grid style

### DIFF
--- a/components/grid/styles.tsx
+++ b/components/grid/styles.tsx
@@ -1,0 +1,25 @@
+import styled from 'styled-components';
+
+interface ColPropsType {
+  span: number;
+}
+
+export const Grid = styled.div``;
+export const Row = styled.div`
+  &::after {
+    content: '';
+    clear: both;
+    display: table;
+  }
+`;
+
+const getWidthString = (span: number) => {
+  const width = (span / 12) * 100;
+  return `width: ${width}%;`;
+};
+
+export const Col = styled.div`
+  float: left;
+  ${(props: ColPropsType) =>
+    props.span ? getWidthString(props.span) : 'width:100%'}
+`;

--- a/components/grid/styles.tsx
+++ b/components/grid/styles.tsx
@@ -1,7 +1,8 @@
 import styled from 'styled-components';
 
 interface ColPropsType {
-  span: number;
+  span?: number;
+  offset?: number;
 }
 
 export const Grid = styled.div``;
@@ -18,8 +19,15 @@ const getWidthString = (span: number) => {
   return `width: ${width}%;`;
 };
 
+const getOffsetString = (offset: number) => {
+  const margin = (offset / 12) * 100;
+  return `margin-left: ${margin}%;`;
+};
+
 export const Col = styled.div`
   float: left;
   ${(props: ColPropsType) =>
-    props.span ? getWidthString(props.span) : 'width:100%'}
+    props.span ? getWidthString(props.span) : 'width:100%'};
+  ${(props: ColPropsType) =>
+    props.offset ? getOffsetString(props.offset) : null};
 `;

--- a/pages/board.tsx
+++ b/pages/board.tsx
@@ -1,0 +1,1 @@
+export { default } from '../views/board';

--- a/views/board/index.tsx
+++ b/views/board/index.tsx
@@ -9,35 +9,55 @@ const Board: React.FC = () => {
         <Grid>
           <Row>
             <Col span={3}>
-              <S.Col1>이건 3짜리 column</S.Col1>
+              <S.Col1>
+                <h2>이건 3짜리 column</h2>
+              </S.Col1>
             </Col>
             <Col span={3}>
-              <S.Col1>이건 3짜리 column</S.Col1>
+              <S.Col1>
+                <h2>이건 3짜리 column</h2>
+              </S.Col1>
             </Col>
             <Col span={3}>
-              <S.Col1>이건 3짜리 column</S.Col1>
+              <S.Col1>
+                <h2>이건 3짜리 column</h2>
+              </S.Col1>
             </Col>
             <Col span={3}>
-              <S.Col1>이건 3짜리 column</S.Col1>
+              <S.Col1>
+                <h2>이건 3짜리 column</h2>
+              </S.Col1>
             </Col>
           </Row>
           <Row>
             <Col span={6}>
-              <S.Col2>이건 6짜리 column</S.Col2>
+              <S.Col2>
+                <h2>이건 6짜리 column</h2>
+              </S.Col2>
             </Col>
             <Col span={6}>
-              <S.Col2>이건 6짜리 column</S.Col2>
+              <S.Col2>
+                <h2>이건 6짜리 column</h2>
+              </S.Col2>
             </Col>
           </Row>
           <Row>
-            <Col span={12}>
-              <S.Col3>이건 12짜리 column</S.Col3>
-            </Col>
             <Col span={3}>
-              <S.Col3>이건 3짜리 column</S.Col3>
+              <S.Col3>
+                <h2>이건 3짜리 column</h2>
+              </S.Col3>
             </Col>
             <Col span={10}>
-              <S.Col3>이건 10짜리 column</S.Col3>
+              <S.Col3>
+                <h2>이건 10짜리 column</h2>
+              </S.Col3>
+            </Col>
+          </Row>
+          <Row>
+            <Col span={4} offset={4}>
+              <S.Col1>
+                <h2>4짜리 column을 4만큼 당기기</h2>
+              </S.Col1>
             </Col>
           </Row>
         </Grid>

--- a/views/board/index.tsx
+++ b/views/board/index.tsx
@@ -1,0 +1,49 @@
+import * as S from './styles';
+import Layout from '../../components/layout';
+import { Grid, Row, Col } from '../../components/grid/styles';
+// for grid test purpose
+const Board: React.FC = () => {
+  return (
+    <Layout>
+      <S.Board>
+        <Grid>
+          <Row>
+            <Col span={3}>
+              <S.Col1>이건 3짜리 column</S.Col1>
+            </Col>
+            <Col span={3}>
+              <S.Col1>이건 3짜리 column</S.Col1>
+            </Col>
+            <Col span={3}>
+              <S.Col1>이건 3짜리 column</S.Col1>
+            </Col>
+            <Col span={3}>
+              <S.Col1>이건 3짜리 column</S.Col1>
+            </Col>
+          </Row>
+          <Row>
+            <Col span={6}>
+              <S.Col2>이건 6짜리 column</S.Col2>
+            </Col>
+            <Col span={6}>
+              <S.Col2>이건 6짜리 column</S.Col2>
+            </Col>
+          </Row>
+          <Row>
+            <Col span={12}>
+              <S.Col3>이건 12짜리 column</S.Col3>
+            </Col>
+            <Col span={3}>
+              <S.Col3>이건 3짜리 column</S.Col3>
+            </Col>
+            <Col span={10}>
+              <S.Col3>이건 10짜리 column</S.Col3>
+            </Col>
+          </Row>
+        </Grid>
+      </S.Board>
+    </Layout>
+  );
+};
+
+export default Board;

--- a/views/board/styles.tsx
+++ b/views/board/styles.tsx
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+
+export const Board = styled.div`
+  background-color: beige;
+`;
+
+// for grid test purpose
+export const Col1 = styled.div`
+  border: 2px solid red;
+`;
+export const Col2 = styled.div`
+  border: 2px solid blue;
+`;
+
+export const Col3 = styled.div`
+  border: 2px solid green;
+`;


### PR DESCRIPTION
### Component에 grid system 추가
`[용례]`
```js
import { Grid, Row, Col } from '../../components/grid/styles';
const ComponentName: React.FC = () => {
return (
        <Grid>
          <Row>
            <Col span={3}>
                12칸 중 3칸을 차지하는 Column
            </Col>
          </Row>
          <Row>
            <Col span={6}>
                12칸 중 6칸을 차지하는 Column
            </Col>
            <Col span={6}>
                12칸 중 6칸을 차지하는 Column
            </Col>
          </Row>
      )
}
```
`[설명]`
Grid를 사용할 범위를 Grid로 감싸고 (Grid는 별다른 스타일 없음. 의미상)
Row단위로 12열의 줄바꿈이 이루어지므로 (Clearfix) 구분할 Col들을 Row로 감싸고
각 Col들엔 span props로 (type은 number) 12개 중 몇개의 칸을 차지하는 Col인지를 명시한다.

### Board page/view 생성
아직 Grid system 테스트를 위한 코드만 작성해둠