### PR TITLE
Feature/board

### DIFF
--- a/components/global-styles/index.tsx
+++ b/components/global-styles/index.tsx
@@ -52,6 +52,18 @@ const GlobalStyles = createGlobalStyle`
   input[type=password] {
     font-family: "Arial";
   }
+
+  textarea:focus {
+  outline: none;
+  }
+  
+  button:focus {
+    outline: none;
+  }
+
+  input:focus {
+    outline: none;
+  }
 `;
 
 export default GlobalStyles;

--- a/components/header/index.tsx
+++ b/components/header/index.tsx
@@ -23,7 +23,7 @@ const Header: React.FC = () => {
               <S.MenuContainer>
                 <S.MenuItem>About</S.MenuItem>
                 <S.MenuItem>Portfolio</S.MenuItem>
-                <S.MenuItem>Recrult</S.MenuItem>
+                <S.MenuItem>Recruit</S.MenuItem>
                 <Link href="/board">
                   <S.MenuItem>Board</S.MenuItem>
                 </Link>

--- a/components/header/index.tsx
+++ b/components/header/index.tsx
@@ -21,13 +21,21 @@ const Header: React.FC = () => {
             </Col>
             <Col span={6} offset={1}>
               <S.MenuContainer>
-                <S.MenuItem>About</S.MenuItem>
-                <S.MenuItem>Portfolio</S.MenuItem>
-                <S.MenuItem>Recruit</S.MenuItem>
+                <Link href="about">
+                  <S.MenuItem>About</S.MenuItem>
+                </Link>
+                <Link href="/portfolio">
+                  <S.MenuItem>Portfolio</S.MenuItem>
+                </Link>
+                <Link href="/recruit">
+                  <S.MenuItem>Recruit</S.MenuItem>
+                </Link>
                 <Link href="/board">
                   <S.MenuItem>Board</S.MenuItem>
                 </Link>
-                <S.MenuItem>Gallery</S.MenuItem>
+                <Link href="/gallery">
+                  <S.MenuItem>Gallery</S.MenuItem>
+                </Link>
               </S.MenuContainer>
             </Col>
             <Col span={2} offset={1}>

--- a/components/pagiationbar/index.tsx
+++ b/components/pagiationbar/index.tsx
@@ -11,12 +11,12 @@ const Pagination: React.FC<PaginationProps> = ({
   numberOfPosts,
   updatePage,
 }) => {
-  const numberOfPages = Math.ceil(numberOfPosts / 10);
   const pagesArray = Array();
+  const numberOfPages = Math.ceil(numberOfPosts / 10);
   const [page, setPage] = useState({
     start: 1,
     current: 1,
-    end: numberOfPages < 3 ? numberOfPages : 3,
+    end: 1,
   });
   for (let i = page.start; i < page.end + 1; i++) {
     pagesArray.push(i);
@@ -36,7 +36,10 @@ const Pagination: React.FC<PaginationProps> = ({
       {button}
     </S.PageButton>
   ));
-  console.log(page);
+  console.log('page', page);
+  useEffect(() => {
+    setPage({ ...page, end: numberOfPages < 5 ? numberOfPages : 5 });
+  }, [numberOfPosts]);
   useEffect(() => {
     updatePage(page.current);
   }, [page.current]);
@@ -44,7 +47,8 @@ const Pagination: React.FC<PaginationProps> = ({
     <S.PaginationBar>
       <S.PageButton
         onClick={() => {
-          if (page.start === 1) return alert('이전 페이지가 존재하지 않습니다');
+          if (page.start === 1 && page.current === 1)
+            return alert('이전 페이지가 존재하지 않습니다');
           if (page.current > page.start) {
             setPage({
               ...page,
@@ -65,7 +69,7 @@ const Pagination: React.FC<PaginationProps> = ({
       {PageButtons}
       <S.PageButton
         onClick={() => {
-          if (page.end === numberOfPages)
+          if (page.end === numberOfPages && page.current === page.end)
             return alert('다음 페이지가 존재하지 않습니다');
           if (page.current < page.end) {
             setPage({

--- a/components/pagiationbar/index.tsx
+++ b/components/pagiationbar/index.tsx
@@ -1,0 +1,81 @@
+import * as S from './styles';
+import axios from 'axios';
+import { useState, useEffect } from 'react';
+
+interface PaginationProps {
+  numberOfPosts: number;
+  updatePage;
+}
+
+const Pagination: React.FC<PaginationProps> = ({
+  numberOfPosts,
+  updatePage,
+}) => {
+  const numberOfPages = Math.ceil(numberOfPosts / 10);
+  const pagesArray = Array();
+  const [page, setPage] = useState({
+    start: 1,
+    current: 1,
+    end: numberOfPages < 3 ? numberOfPages : 3,
+  });
+  for (let i = page.start; i < page.end + 1; i++) {
+    pagesArray.push(i);
+  }
+  const PageButtons = pagesArray.map((button, i) => (
+    <S.PageButton
+      key={i}
+      onClick={() => {
+        setPage({ ...page, current: button });
+      }}
+    >
+      {button}
+    </S.PageButton>
+  ));
+  console.log(page);
+  useEffect(() => {
+    updatePage(page.current);
+  }, [page.current]);
+  return (
+    <S.PaginationBar>
+      <S.PageButton
+        onClick={() => {
+          if (page.start === 1) return alert('이전 페이지가 존재하지 않습니다');
+          else {
+            setPage({
+              ...page,
+              start: page.start - 1,
+              current: page.current - 1,
+              end: page.end - 1,
+            });
+          }
+        }}
+      >
+        {'<'}
+      </S.PageButton>
+      {PageButtons}
+      <S.PageButton
+        onClick={() => {
+          if (page.end === numberOfPages)
+            return alert('다음 페이지가 존재하지 않습니다');
+          if (page.current < page.end) {
+            setPage({
+              ...page,
+              current: page.current + 1,
+            });
+          } else {
+            setPage({
+              ...page,
+              start: page.start + 1,
+              current: page.current + 1,
+              end: page.end + 1,
+            });
+          }
+        }}
+      >
+        {'>'}
+      </S.PageButton>
+    </S.PaginationBar>
+  );
+};
+
+export default Pagination;

--- a/components/pagiationbar/index.tsx
+++ b/components/pagiationbar/index.tsx
@@ -27,6 +27,11 @@ const Pagination: React.FC<PaginationProps> = ({
       onClick={() => {
         setPage({ ...page, current: button });
       }}
+      style={
+        button == page.current
+          ? { fontWeight: 'bold', backgroundColor: '#c93333', color: 'white' }
+          : null
+      }
     >
       {button}
     </S.PageButton>
@@ -40,7 +45,12 @@ const Pagination: React.FC<PaginationProps> = ({
       <S.PageButton
         onClick={() => {
           if (page.start === 1) return alert('이전 페이지가 존재하지 않습니다');
-          else {
+          if (page.current > page.start) {
+            setPage({
+              ...page,
+              current: page.current - 1,
+            });
+          } else {
             setPage({
               ...page,
               start: page.start - 1,

--- a/components/pagiationbar/styles.tsx
+++ b/components/pagiationbar/styles.tsx
@@ -1,0 +1,20 @@
+import styled from 'styled-components';
+
+export const PaginationBar = styled.div`
+  display: flex;
+  margin: 2rem 0;
+  font-size: 1.4rem;
+  justify-content: center;
+`;
+
+export const PageButton = styled.button`
+  color: black;
+  border: none;
+  float: left;
+  padding: 8px 16px;
+  font-weight: bold;
+  &:hover {
+    background-color: #4caf50;
+    color: white;
+  }
+`;

--- a/components/pagiationbar/styles.tsx
+++ b/components/pagiationbar/styles.tsx
@@ -14,7 +14,6 @@ export const PageButton = styled.button`
   padding: 8px 16px;
   font-weight: bold;
   &:hover {
-    background-color: #4caf50;
-    color: white;
+    color: #c93333;
   }
 `;

--- a/views/board/hook.js
+++ b/views/board/hook.js
@@ -1,0 +1,17 @@
+// for fetching data
+import axios from 'axios';
+
+const baseURL = 'http://localhost:4000/post';
+
+export const getPage = page => {
+  const request = axios.get(`${baseURL}/?page=${page}`);
+  return request.then(response => response.data);
+};
+
+export const getPost = postId => {
+  const request = axios.get(`${baseURL}/${postId}`);
+  return request.then(response => {
+    console.log(response.data);
+    return response.data;
+  });
+};

--- a/views/board/index.tsx
+++ b/views/board/index.tsx
@@ -4,6 +4,7 @@ import { Grid, Row, Col } from '../../components/grid/styles';
 import Link from 'next/link';
 import axios, { AxiosResponse } from 'axios';
 import { useState, useEffect } from 'react';
+import Pagination from '../../components/pagiationbar';
 
 const baseURL = 'http://localhost:4000/post';
 
@@ -16,7 +17,6 @@ const getPage = page => {
 
 // dummies
 const BoardMenuList = ['공지', '자유게시판', '교우게시판'];
-
 const BoardNavItems = BoardMenuList.map((Item, i) => (
   <li key={i}>
     <S.BoardNavItem>
@@ -28,11 +28,14 @@ const BoardNavItems = BoardMenuList.map((Item, i) => (
 
 const Board: React.FC = () => {
   const [posts, setPosts] = useState<Array<any> | null>([]);
+  const updatePage = id => {
+    getPage(id).then(returnedData => setPosts(returnedData));
+  };
   const showPost =
     posts &&
-    posts.map(post => {
+    posts.map((post, i) => {
       return (
-        <S.BoardPost>
+        <S.BoardPost key={i}>
           <S.BoardIndexAuthor>{post.userId}</S.BoardIndexAuthor>
           <S.BoardIndexTitle>{post.title}</S.BoardIndexTitle>
           <S.BoardIndexLikes>{post.likes}</S.BoardIndexLikes>
@@ -72,11 +75,11 @@ const Board: React.FC = () => {
                   </S.BoardIndex>
                   {showPost}
                 </S.BoardContent>
-                <S.BoardPagination>1 | 2 | 3 | 4</S.BoardPagination>
               </Col>
             </S.BoardContainer>
           </Row>
         </Grid>
+        <Pagination numberOfPosts={34} updatePage={updatePage} />
       </S.Board>
     </Layout>
   );

--- a/views/board/index.tsx
+++ b/views/board/index.tsx
@@ -1,19 +1,10 @@
 import * as S from './styles';
+import { useState, useEffect } from 'react';
 import Layout from '../../components/layout';
 import { Grid, Row, Col } from '../../components/grid/styles';
-import Link from 'next/link';
-import axios, { AxiosResponse } from 'axios';
-import { useState, useEffect } from 'react';
+import { useRouter } from 'next/router';
+import axios from 'axios';
 import Pagination from '../../components/pagiationbar';
-
-const baseURL = 'http://localhost:4000/post';
-
-const getPage = page => {
-  const request = axios.get(`${baseURL}/?page=${page}`);
-  return request
-    .then(response => response.data)
-    .then(responseData => responseData.data);
-};
 
 // dummies
 const BoardMenuList = ['공지', '자유게시판', '교우게시판'];
@@ -26,16 +17,28 @@ const BoardNavItems = BoardMenuList.map((Item, i) => (
   </li>
 ));
 
+// for fetching data
+const baseURL = 'http://localhost:4000/post';
+const getPage = page => {
+  const request = axios.get(`${baseURL}/?page=${page}`);
+  return request.then(response => response.data);
+};
+
 const Board: React.FC = () => {
+  const router = useRouter();
   const [posts, setPosts] = useState<Array<any> | null>([]);
+  const [numberOfPosts, setNumberOfPosts] = useState(null);
   const updatePage = id => {
-    getPage(id).then(returnedData => setPosts(returnedData));
+    getPage(id).then(returnedData => {
+      setPosts(returnedData.data);
+      setNumberOfPosts(returnedData.count);
+    });
   };
   const showPost =
     posts &&
     posts.map((post, i) => {
       return (
-        <S.BoardPost key={i}>
+        <S.BoardPost key={i} onClick={() => getPage(post.id)}>
           <S.BoardIndexAuthor>{post.userId}</S.BoardIndexAuthor>
           <S.BoardIndexTitle>{post.title}</S.BoardIndexTitle>
           <S.BoardIndexLikes>{post.likes}</S.BoardIndexLikes>
@@ -45,7 +48,7 @@ const Board: React.FC = () => {
       );
     });
   useEffect(() => {
-    getPage(1).then(returnedData => setPosts(returnedData));
+    getPage(1).then(returnedData => setPosts(returnedData.data));
   }, []);
   return (
     <Layout>
@@ -79,7 +82,7 @@ const Board: React.FC = () => {
             </S.BoardContainer>
           </Row>
         </Grid>
-        <Pagination numberOfPosts={34} updatePage={updatePage} />
+        <Pagination numberOfPosts={numberOfPosts} updatePage={updatePage} />
       </S.Board>
     </Layout>
   );

--- a/views/board/index.tsx
+++ b/views/board/index.tsx
@@ -2,9 +2,9 @@ import * as S from './styles';
 import { useState, useEffect } from 'react';
 import Layout from '../../components/layout';
 import { Grid, Row, Col } from '../../components/grid/styles';
-import { useRouter } from 'next/router';
-import axios from 'axios';
 import Pagination from '../../components/pagiationbar';
+import Post from '../../components/post';
+import { getPage, getPost } from './hook';
 
 // dummies
 const BoardMenuList = ['공지', '자유게시판', '교우게시판'];
@@ -17,15 +17,7 @@ const BoardNavItems = BoardMenuList.map((Item, i) => (
   </li>
 ));
 
-// for fetching data
-const baseURL = 'http://localhost:4000/post';
-const getPage = page => {
-  const request = axios.get(`${baseURL}/?page=${page}`);
-  return request.then(response => response.data);
-};
-
 const Board: React.FC = () => {
-  const router = useRouter();
   const [posts, setPosts] = useState<Array<any> | null>([]);
   const [numberOfPosts, setNumberOfPosts] = useState(null);
   const updatePage = id => {
@@ -37,15 +29,7 @@ const Board: React.FC = () => {
   const showPost =
     posts &&
     posts.map((post, i) => {
-      return (
-        <S.BoardPost key={i} onClick={() => getPage(post.id)}>
-          <S.BoardIndexAuthor>{post.userId}</S.BoardIndexAuthor>
-          <S.BoardIndexTitle>{post.title}</S.BoardIndexTitle>
-          <S.BoardIndexLikes>{post.likes}</S.BoardIndexLikes>
-          <S.BoardIndexDate>{post.createdAt.substring(0, 10)}</S.BoardIndexDate>
-          <S.BoardIndexViews>{post.views}</S.BoardIndexViews>
-        </S.BoardPost>
-      );
+      return <Post getPost={getPost} post={post} key={i} />;
     });
   useEffect(() => {
     getPage(1).then(returnedData => setPosts(returnedData.data));

--- a/views/board/styles.tsx
+++ b/views/board/styles.tsx
@@ -3,15 +3,13 @@ import styled from 'styled-components';
 export const Board = styled.div``;
 
 export const BoardContainer = styled.div`
-  /* border: 1px solid #d6d6d6; */
+  border: 1px solid #d6d6d6;
   width: 100%;
   max-width: 136.6rem;
   min-width: 96rem;
   margin: 0 auto;
-  min-height: 49.5rem;
+  min-height: 45rem;
 `;
-
-// for grid test purpose
 
 export const BoardNavbar = styled.ul`
   font-size: 1.8rem;
@@ -94,11 +92,4 @@ export const BoardPost = styled.div`
   align-items: center;
   font-size: 1.2rem;
   border-bottom: 1px solid #d6d6d6;
-`;
-
-export const BoardPagination = styled.div`
-  display: flex;
-  margin: 2rem 0;
-  font-size: 1.4rem;
-  justify-content: center;
 `;

--- a/views/board/styles.tsx
+++ b/views/board/styles.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 export const Board = styled.div``;
 
 export const BoardContainer = styled.div`
-  border: 1px solid #d6d6d6;
   width: 100%;
   max-width: 136.6rem;
   min-width: 96rem;


### PR DESCRIPTION
한 페이지당 10개씩 끊어서 post 목록 보여주는 pagination 기능 구현.
버튼 누르면 그때그때 post?page=n 으로 요청 보내서 10개씩 받아오는 식.

- 전체 Post 갯수가 50개 이하면 (5페이지 미만이면) 필요한 페이지 만큼만 페이지 버튼이 만들어짐 (ex. 총 포스트 수 25개면 버튼 3개)
- 전체 Post 갯수가 50개 초과면 (5페이지보다 많으면) 페이지네이션 버튼은 5개 < > 버튼으로 이전 페이지 / 다음 페이지 이동 가능.

Pagination 기능만 component에 분리했음.

+) 코드 모듈화가 안되어 있어 관훈이의 필요. 서버와 통신하고 response data를 정제하는 코드들을 별개의 폴더로 빼고 싶은데 보통 그렇게들 많이 하는지 궁금.